### PR TITLE
Add local metadata support for LoRA

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ To quickly save a generated image as the preview to use for the model, you can r
 ![image](https://github.com/pythongosssss/ComfyUI-Custom-Scripts/assets/125205205/6b67bf40-ee17-4fa6-a0c1-7947066bafc2)
 ![image](https://github.com/pythongosssss/ComfyUI-Custom-Scripts/assets/125205205/32405df6-b367-404f-a5df-2d4347089a9e)  
 Adds "View Info" menu option to view details about the selected LoRA or Checkpoint. To view embedding details, click the info button when using embedding autocomplete.
+LoRA情報はローカルの `metadata.json` を参照します。
 
 ## Constrain Image
 Adds a node for resizing an image to a max & min size optionally cropping if required.

--- a/py/model_info.py
+++ b/py/model_info.py
@@ -113,3 +113,45 @@ async def load_metadata(request):
             f.write(meta["pysssss.sha256"])
 
     return web.json_response(meta)
+
+
+@PromptServer.instance.routes.get("/pysssss/local_metadata/{name}")
+async def load_local_metadata(request):
+    name = request.match_info["name"]
+    pos = name.index("/")
+    type = name[:pos]
+    name = name[pos+1:]
+
+    file_path = None
+    if type == "embeddings" or type == "loras":
+        name = name.lower()
+        files = folder_paths.get_filename_list(type)
+        for f in files:
+            lower_f = f.lower()
+            if lower_f == name:
+                file_path = folder_paths.get_full_path(type, f)
+            else:
+                n = os.path.splitext(f)[0].lower()
+                if n == name:
+                    file_path = folder_paths.get_full_path(type, f)
+
+            if file_path is not None:
+                break
+    else:
+        file_path = folder_paths.get_full_path(type, name)
+    if not file_path:
+        return web.Response(status=404)
+
+    file_no_ext = os.path.splitext(file_path)[0]
+    meta_path = None
+    if os.path.isfile(file_path + ".metadata.json"):
+        meta_path = file_path + ".metadata.json"
+    elif os.path.isfile(file_no_ext + ".metadata.json"):
+        meta_path = file_no_ext + ".metadata.json"
+    if not meta_path:
+        return web.Response(status=404)
+
+    with open(meta_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    return web.json_response(data)

--- a/web/js/common/modelInfoDialog.js
+++ b/web/js/common/modelInfoDialog.js
@@ -214,19 +214,19 @@ export class ModelInfoDialog extends ComfyDialog {
 		);
 	}
 
-	async getCivitaiDetails() {
-		const req = await fetch("https://civitai.com/api/v1/model-versions/by-hash/" + this.hash);
-		if (req.status === 200) {
-			return await req.json();
-		} else if (req.status === 404) {
-			throw new Error("Model not found");
-		} else {
-			throw new Error(`Error loading info (${req.status}) ${req.statusText}`);
-		}
-	}
+       async getLocalMetadata() {
+               const req = await fetch("/pysssss/local_metadata/" + encodeURIComponent(this.type + "/" + this.name));
+               if (req.status === 200) {
+                       return await req.json();
+               } else if (req.status === 404) {
+                       throw new Error("Metadata not found");
+               } else {
+                       throw new Error(`Error loading info (${req.status}) ${req.statusText}`);
+               }
+       }
 
-	addCivitaiInfo() {
-		const promise = this.getCivitaiDetails();
+       addCivitaiInfo() {
+               const promise = this.getLocalMetadata();
 		const content = $el("span", { textContent: "ℹ️ Loading..." });
 
 		this.addInfoEntry(

--- a/web/js/modelInfo.js
+++ b/web/js/modelInfo.js
@@ -174,10 +174,8 @@ export class LoraInfoDialog extends ModelInfoDialog {
 		);
 
 		super.addInfo();
-		const p = this.addCivitaiInfo();
+		const info = await this.getLocalMetadata().catch(() => null);
 		this.addTags();
-
-		const info = await p;
 		this.addExample("Trained Words", info?.trainedWords?.join(", ") ?? "", "trainedwords");
 
 		const triggerPhrase = this.metadata["modelspec.trigger_phrase"];


### PR DESCRIPTION
## Summary
- provide an API to return local metadata.json for models
- fetch local metadata from the frontend
- show LoRA details using the local metadata instead of Civitai
- document the change in README

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887a9d9cd1883219416be72a5d72e4d